### PR TITLE
Bump `nest-next` version

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,7 @@
     "cache-manager": "^2.9.0",
     "dotenv": "^6.1.0",
     "joi": "^14.0.0",
-    "nest-next": "0.2",
+    "nest-next": "0.4",
     "next": "8",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",


### PR DESCRIPTION
Update version from `0.2`->`0.4` (I used this as a boilerplate to a project/hadn't noticed. The version in here should definitely be up to date).

Definitely not needed if #15 is merged first, but seems like there's still some work needed around the example on that PR.