### PR TITLE
Next 9.0.6 support

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "@nestjs/common": "^6.5.3",
     "@nestjs/core": "^6.5.3",
     "@nestjs/platform-express": "^6.5.3",
-    "nest-next": "9.0.0-beta.0",
+    "nest-next": "^9.0.6",
     "next": "^9.0.3",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
@@ -23,11 +23,11 @@
     "rxjs": "^6.5.2"
   },
   "devDependencies": {
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
     "@types/node": "^12.7.1",
     "@types/react": "^16.9.1",
     "ts-node": "^8.3.0",
-    "typescript": "^3.5.3",
-    "@babel/cli": "^7.5.5",
-    "@babel/core": "^7.5.5"
+    "typescript": "^3.5.3"
   }
 }

--- a/lib/render.filter.ts
+++ b/lib/render.filter.ts
@@ -16,7 +16,7 @@ export class RenderFilter implements ExceptionFilter {
    * Nest isn't aware of how next handles routing for the build assets, let next
    * handle routing for any request that isn't handled by a controller
    * @param err
-   * @param ctx
+   * @param host
    */
   public async catch(err: any, host: ArgumentsHost) {
     const ctx = host.switchToHttp();

--- a/lib/render.module.ts
+++ b/lib/render.module.ts
@@ -1,10 +1,14 @@
 import { INestApplication, Module } from '@nestjs/common';
-import  Server from 'next-server';
+import Server from 'next';
 import { RenderFilter } from './render.filter';
 import { RenderService } from './render.service';
 import { RendererConfig } from './types';
 
-type INestAppliactionSubset = Pick<INestApplication, 'getHttpAdapter' | 'useGlobalFilters'> & Partial<INestApplication>;
+type INestAppliactionSubset = Pick<
+  INestApplication,
+  'getHttpAdapter' | 'useGlobalFilters'
+> &
+  Partial<INestApplication>;
 @Module({
   providers: [RenderService],
 })

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "@nestjs/common": "^6.0",
     "@nestjs/core": "^6.0",
     "@nestjs/platform-fastify": "^6.0",
-    "next": "^9.0",
+    "next": "^9.0.6",
     "rxjs": "^6.4"
+  },
+  "peerDependencies": {
+    "next": "^9.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@nestjs/common": "^6.0",
     "@nestjs/core": "^6.0",
     "@nestjs/platform-fastify": "^6.0",
-    "next-server": "^9.0",
+    "next": "^9.0",
     "rxjs": "^6.4"
   }
 }


### PR DESCRIPTION
Added support for Next 9.0.6 by taking the Server type from "next" instead of "next-server" (once again).

I originally made the change from "next" to "next-server" in my previous PR with the idea of minimizing the dependencies, but that was under the assumption that next-server will persist as a separate dependency of "next".

I also used the opportunity for a "prettier" pass, and a doc fix in render.filter.ts.

This should fix #22 and #24.