### PR TITLE
Type safety for injected responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Additionally, the render function is made available on the res object.
 export class AppController {
 
   @Get()
-  public index(@Res() res) {
+  public index(@Res() res: RenderableResponse) {
     res.render('Index', {
       title: 'Next with Nest',
     });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,12 +2,18 @@ import { ParsedUrlQuery } from 'querystring';
 
 export type RequestHandler = (req: any, res: any, query?: any) => Promise<void>;
 
-export type Renderer = (
+export type Renderer<DataType extends ParsedUrlQuery = ParsedUrlQuery> = (
   req: any,
   res: any,
   view: string,
-  params?: any,
+  params?: DataType,
 ) => Promise<void>;
+
+export interface RenderableResponse<
+  DataType extends ParsedUrlQuery = ParsedUrlQuery
+> {
+  render(view: string, data?: DataType): ReturnType<Renderer<DataType>>;
+}
 
 export type ErrorRenderer = (
   err: any,


### PR DESCRIPTION
Added a type for the render method, allowing injected responses to become type safe when injected.

The README.md illustrates using the new type alone, though in a real application, one could add it as a union with the fastify or express response type (depending on what they use), in order to enable all methods.

The type of "data" is also narrowed down to an extension of ParsedUrlQuery, since that's where the data ultimately ends at. This effectively stops non-objects from being passed.