### PR TITLE
Made the whole registration flow more aligned with NestJS's standard organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,43 +36,16 @@
 
 ### Import and register the RenderModule
 
-In the `main.ts`, import Next and prepare it. Get the `RenderService` and register it by passing it the
-Nest application and next server.
-
-```typescript
-import { NestFactory } from '@nestjs/core';
-import { RenderModule } from 'nest-next';
-import Next from 'next';
-import 'reflect-metadata';
-import { AppModule } from './application.module';
-
-async function bootstrap() {
-  const dev = process.env.NODE_ENV !== 'production';
-  const app = Next({ dev });
-
-  await app.prepare();
-
-  const server = await NestFactory.create(AppModule);
-
-  const renderer = server.get(RenderModule);
-  renderer.register(server, app);
-
-  await server.listen(process.env.PORT || 3000);
-}
-
-bootstrap();
-
-```
-
-In the `application.module.ts` import the RenderModule.
+Import the RenderModule into your application's root module.
 
 ```typescript
 import { Module } from '@nestjs/common';
+import Next from 'next';
 import { RenderModule } from 'nest-next';
 
 @Module({
   imports: [
-    RenderModule,
+    RenderModule.forRootAsync(Next({ dev: process.env.NODE_ENV !== 'production' })),
     ...
   ],
   ....
@@ -80,7 +53,9 @@ import { RenderModule } from 'nest-next';
 export class AppModule {}
 ```
 
-### Default Settings
+### Settings
+
+Settings to the RenderModule can be passed as the second argument of forRootAsync() above.
 
 ```typescript
 interface RenderOptions {
@@ -92,10 +67,9 @@ interface RenderOptions {
 **Views/Pages Folder**
 
 By default the the renderer will serve pages from the `/pages/views` dir. Due to limitations with
-Next the `/pages` dir is not configurable, but the directory within the `/pages` dir is configurable.
+Next, the `/pages` dir is not configurable, but the directory within the `/pages` dir is configurable.
 
-The `register` method on the `RenderModule` takes an optional parameter `viewsDir` which determine the
-folder inside of `pages` to render from. By default the value is `/views` but this can be changed or
+The `viewsDir` option determines the folder inside of `pages` to render from. By default the value is `/views` but this can be changed or
 set to null to render from the root of `pages`.
 
 **Dev Mode**
@@ -183,9 +157,6 @@ You can set the error handler by getting the RenderService from nest's container
 const main() => {
   ...
 
-  const renderer = server.get(RenderModule);
-  renderer.register(server, app);
-
   // get the RenderService
   const service = server.get(RenderService);
 
@@ -252,6 +223,11 @@ outside of both projects. Changes in it during "dev" runs trigger recompilation 
         /AboutPage.ts
         /IndexPage.ts
       package.json
+      
+
+To run this project, the "ui" and "server" project must be built, in any order. The "dto" project will be implicitly built by the "server" project. After both of those builds, the "server" project can be started in either dev or production mode.
+
+It is important that "ui" references to "dto" refer to the TypeScript files (.ts files in the "src" folder), and NOT the declaration files (.d.ts files in the "dist" folder), due to how Next not being compiled in the same fashion as the server.
 
 ## Configuring Next
 

--- a/examples/basic/src/application.module.ts
+++ b/examples/basic/src/application.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
 import { RenderModule } from 'nest-next';
+import Next from 'next';
 import { AppController } from './app.controller';
 
 @Module({
-  imports: [RenderModule],
-  controllers: [AppController]
+  imports: [
+    RenderModule.forRootAsync(
+      Next({ dev: process.env.NODE_ENV !== 'production' }),
+    ),
+  ],
+  controllers: [AppController],
 })
 export class AppModule {}

--- a/examples/basic/src/main.ts
+++ b/examples/basic/src/main.ts
@@ -1,19 +1,8 @@
 import { NestFactory } from '@nestjs/core';
-import { RenderModule } from 'nest-next';
-import Next from 'next';
-import 'reflect-metadata';
 import { AppModule } from './application.module';
 
 async function bootstrap() {
-  const dev = process.env.NODE_ENV !== 'production';
-  const app = Next({ dev });
-
-  await app.prepare();
-
   const server = await NestFactory.create(AppModule);
-
-  const renderer = server.get(RenderModule);
-  renderer.register(server, app);
 
   await server.listen(3000);
 }

--- a/examples/monorepo/README.md
+++ b/examples/monorepo/README.md
@@ -3,3 +3,7 @@
 This example demonstrates how to use nest-next to add server side rendering to [nest](https://github.com/nestjs/nest) with [next.js](https://github.com/zeit/next.js/).
 
 All needed components are expected to be in a mono repo with multiple projects, with this folder being the root of the repo.
+
+To run this project, the "ui" and "server" project must be built, in any order. The "dto" project will be implicitly built by the "server" project. After both of those builds, the "server" project can be started in either dev or production mode.
+
+It is important that "ui" references to "dto" refer to the TypeScript files (.ts files in the "src" folder), and NOT the declaration files (.d.ts files in the "dist" folder), due to how Next not being compiled in the same fashion as the server.

--- a/examples/monorepo/server/src/application.module.ts
+++ b/examples/monorepo/server/src/application.module.ts
@@ -1,9 +1,18 @@
 import { Module } from '@nestjs/common';
 import { RenderModule } from 'nest-next';
+import Next from 'next';
+import { resolve } from 'path';
 import { AppController } from './app.controller';
 
 @Module({
   controllers: [AppController],
-  imports: [RenderModule],
+  imports: [
+    RenderModule.forRootAsync(
+      Next({
+        dev: process.env.NODE_ENV !== 'production',
+        dir: resolve(__dirname, '../../ui'),
+      }),
+    ),
+  ],
 })
 export class AppModule {}

--- a/examples/monorepo/server/src/main.ts
+++ b/examples/monorepo/server/src/main.ts
@@ -1,22 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
-import { RenderModule } from 'nest-next';
-import Next from 'next';
-import { resolve } from 'path';
 import 'reflect-metadata';
 import { AppModule } from './application.module';
 
 async function bootstrap() {
-  const dev = process.env.NODE_ENV !== 'production';
-  const dir = resolve(__dirname, '../../ui');
-  const app = Next({ dev, dir });
-
-  await app.prepare();
-
   const server = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter());
-
-  const renderer = server.get(RenderModule);
-  renderer.register(server, app, { viewsDir: '' });
 
   await server.listen(3000);
 }

--- a/lib/render.filter.ts
+++ b/lib/render.filter.ts
@@ -32,6 +32,14 @@ export class RenderFilter implements ExceptionFilter {
       const requestHandler = this.service.getRequestHandler();
       const errorRenderer = this.service.getErrorRenderer();
 
+      // these really should already always be set since it is done during the module registration
+      // if somehow they aren't throw an error
+      if (!requestHandler || !errorRenderer) {
+        throw new Error(
+          'Request and/or error renderer not set on RenderService',
+        );
+      }
+
       const isFastify = !!response.res;
 
       const res: ServerResponse = isFastify ? response.res : response;

--- a/lib/render.module.ts
+++ b/lib/render.module.ts
@@ -1,37 +1,50 @@
-import { INestApplication, Module } from '@nestjs/common';
+import { DynamicModule } from '@nestjs/common';
+import { ApplicationConfig, HttpAdapterHost } from '@nestjs/core';
 import Server from 'next';
 import { RenderFilter } from './render.filter';
 import { RenderService } from './render.service';
 import { RendererConfig } from './types';
 
-type INestAppliactionSubset = Pick<
-  INestApplication,
-  'getHttpAdapter' | 'useGlobalFilters'
-> &
-  Partial<INestApplication>;
-@Module({
-  providers: [RenderService],
-})
 export class RenderModule {
-  private app?: INestAppliactionSubset;
-  private server?: ReturnType<typeof Server>;
-
-  constructor(private readonly service: RenderService) {}
-
-  public register(
-    app: INestAppliactionSubset,
-    server: ReturnType<typeof Server>,
+  public static async forRootAsync(
+    next: ReturnType<typeof Server>,
     options: Partial<RendererConfig> = {},
-  ) {
-    this.app = app;
-    this.server = server;
+  ): Promise<DynamicModule> {
+    if (typeof next.prepare === 'function') {
+      await next.prepare();
+    }
 
-    this.service.mergeConfig(options);
-    this.service.setRequestHandler(this.server.getRequestHandler());
-    this.service.setRenderer(this.server.render.bind(this.server));
-    this.service.setErrorRenderer(this.server.renderError.bind(this.server));
-    this.service.bindHttpServer(this.app.getHttpAdapter());
+    return {
+      exports: [RenderService],
+      module: RenderModule,
+      providers: [
+        {
+          inject: [HttpAdapterHost],
+          provide: RenderService,
+          useFactory: (nestHost: HttpAdapterHost): RenderService => {
+            return new RenderService(
+              options,
+              next.getRequestHandler(),
+              next.render.bind(next),
+              next.renderError.bind(next),
+              nestHost.httpAdapter,
+            );
+          },
+        },
+        {
+          inject: [ApplicationConfig, RenderService],
+          provide: RenderFilter,
+          useFactory: (
+            nestConfig: ApplicationConfig,
+            service: RenderService,
+          ) => {
+            const filter = new RenderFilter(service);
+            nestConfig.addGlobalFilter(filter);
 
-    this.app.useGlobalFilters(new RenderFilter(this.service));
+            return filter;
+          },
+        },
+      ],
+    };
   }
 }

--- a/lib/render.module.ts
+++ b/lib/render.module.ts
@@ -1,10 +1,13 @@
-import { DynamicModule } from '@nestjs/common';
+import { DynamicModule, Module } from '@nestjs/common';
 import { ApplicationConfig, HttpAdapterHost } from '@nestjs/core';
 import Server from 'next';
 import { RenderFilter } from './render.filter';
 import { RenderService } from './render.service';
 import { RendererConfig } from './types';
 
+@Module({
+  providers: [RenderService],
+})
 export class RenderModule {
   public static async forRootAsync(
     next: ReturnType<typeof Server>,
@@ -22,7 +25,7 @@ export class RenderModule {
           inject: [HttpAdapterHost],
           provide: RenderService,
           useFactory: (nestHost: HttpAdapterHost): RenderService => {
-            return new RenderService(
+            return RenderService.init(
               options,
               next.getRequestHandler(),
               next.render.bind(next),
@@ -46,5 +49,26 @@ export class RenderModule {
         },
       ],
     };
+  }
+
+  constructor(
+    private readonly httpAdapterHost: HttpAdapterHost,
+    private readonly applicationConfig: ApplicationConfig,
+    private readonly service: RenderService,
+  ) {}
+
+  public register(
+    _app: any,
+    next: ReturnType<typeof Server>,
+    options: Partial<RendererConfig> = {},
+  ) {
+    if (!this.service.isInitialized()) {
+      this.service.mergeConfig(options);
+      this.service.setRequestHandler(next.getRequestHandler());
+      this.service.setRenderer(next.render.bind(next));
+      this.service.setErrorRenderer(next.renderError.bind(next));
+      this.service.bindHttpServer(this.httpAdapterHost.httpAdapter);
+      this.applicationConfig.useGlobalFilters(new RenderFilter(this.service));
+    }
   }
 }

--- a/lib/render.module.ts
+++ b/lib/render.module.ts
@@ -9,6 +9,12 @@ import { RendererConfig } from './types';
   providers: [RenderService],
 })
 export class RenderModule {
+  /**
+   * Registers this module with a Next app at the root of the Nest app.
+   *
+   * @param next The Next app to register.
+   * @param options Options for the RenderModule.
+   */
   public static async forRootAsync(
     next: ReturnType<typeof Server>,
     options: Partial<RendererConfig> = {},
@@ -57,11 +63,26 @@ export class RenderModule {
     private readonly service: RenderService,
   ) {}
 
+  /**
+   * Register the RenderModule.
+   *
+   * @deprecated Use RenderModule.forRootAsync() when importing the module, and remove this post init call.
+   * @param _app Previously, the Nest app. Now ignored.
+   * @param next The Next app.
+   * @param options Options for the RenderModule.
+   */
   public register(
     _app: any,
     next: ReturnType<typeof Server>,
     options: Partial<RendererConfig> = {},
   ) {
+    console.error(
+      'RenderModule.register() is deprecated and will be removed in a future release.',
+    );
+    console.error(
+      'Please use RenderModule.forRootAsync() when importing the module, and remove this post init call.',
+    );
+
     if (!this.service.isInitialized()) {
       this.service.mergeConfig(options);
       this.service.setRequestHandler(next.getRequestHandler());

--- a/lib/render.service.ts
+++ b/lib/render.service.ts
@@ -164,6 +164,9 @@ export class RenderService {
       const req = isFastify ? response.request.raw : response.req;
 
       if (req && res) {
+        if (isFastify) {
+          response.sent = true;
+        }
         return renderer(req, res, getViewPath(view), data);
       } else if (!res) {
         throw new InternalServerErrorException(
@@ -193,6 +196,7 @@ export class RenderService {
         .decorateReply('render', function(view: string, data?: ParsedUrlQuery) {
           const res = this.res;
           const req = this.request.raw;
+          this.sent = true;
 
           return renderer(req, res, getViewPath(view), data);
         } as RenderableResponse['render']);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,7 +2,7 @@ import { ParsedUrlQuery } from 'querystring';
 
 export type RequestHandler = (req: any, res: any, query?: any) => Promise<void>;
 
-export type Renderer<DataType extends ParsedUrlQuery = ParsedUrlQuery> = (
+export type Renderer<DataType extends unknown = ParsedUrlQuery> = (
   req: any,
   res: any,
   view: string,
@@ -10,7 +10,7 @@ export type Renderer<DataType extends ParsedUrlQuery = ParsedUrlQuery> = (
 ) => Promise<void>;
 
 export interface RenderableResponse<
-  DataType extends ParsedUrlQuery = ParsedUrlQuery
+  DataType extends unknown = ParsedUrlQuery
 > {
   render(view: string, data?: DataType): ReturnType<Renderer<DataType>>;
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "publish-public": "yarn publish --access public"
   },
   "devDependencies": {
+    "@nestjs/common": "^6.4",
+    "@nestjs/core": "^6.4",
+    "@nestjs/platform-fastify": "^6.4",
     "@types/node": "^11.12",
     "del-cli": "^2.0",
     "mermaid.cli": "^0.5",
@@ -29,12 +32,11 @@
     "typescript": "^3.3"
   },
   "dependencies": {
-    "@nestjs/common": "^6.0",
-    "@nestjs/core": "^6.0",
-    "@nestjs/platform-fastify": "^6.0",
     "rxjs": "^6.4"
   },
   "peerDependencies": {
+    "@nestjs/common": "^6.4",
+    "@nestjs/core": "^6.4",
     "next": "^9.0.6"
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,11 @@
 {
   "extends": ["tslint:latest", "tslint-config-prettier"],
   "rules": {
+    "no-implicit-dependencies": {
+      "options": [
+        "dev"
+      ]
+    },
     "interface-name": false,
     "only-arrow-functions": false,
     "no-submodule-imports": false


### PR DESCRIPTION
The module is initialized as a normal dynamic module that happens to modify global settings via ApplicationConfig. Bumped required Nest version to 6.4 to enable this. Checks for whether the Next pieces are set are removed, as they are now defined in the constructor.

Nest is now a peer dependency instead of a required one, and @nestjs/platform-fastify is only in dev dependencies, since it's an optional peer dependency.

----

This is marked as work in progress, because for some reason I can't quite understand yet, it seems like fastify is not detected properly in this setup, resulting in runtime errors. Help?