### PR TITLE
Fix missing nodemon dependency

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -3,3 +3,5 @@
 This example demonstrates how to use nest-next to add server side rendering to [nest](https://github.com/nestjs/nest) with [next.js](https://github.com/zeit/next.js/).
 
 All needed components are expected to be under one project, one repo, with this folder being the root of the repo.
+
+> You need to build the project first

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -28,6 +28,7 @@
     "@babel/core": "^7.5.5",
     "@types/node": "^12.7.1",
     "@types/react": "^16.9.1",
+    "nodemon": "^2.0.4",
     "rimraf": "^3.0.0",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"


### PR DESCRIPTION
`nodemon` is missing from basic example dependency

@kyle-mccarthy there is missing dependency on the basic example and I add additional info on readme to run the example