### PR TITLE
Support base path parameter from next config

### DIFF
--- a/lib/render.module.ts
+++ b/lib/render.module.ts
@@ -23,6 +23,15 @@ export class RenderModule {
       await next.prepare();
     }
 
+    const nextConfig = (next as any).nextConfig;
+    const nextServer = (next as any).server;
+
+    const basePath = nextConfig
+      ? nextConfig.basePath
+      : nextServer.nextConfig.basePath;
+
+    const config = { basePath, ...options };
+
     return {
       exports: [RenderService],
       module: RenderModule,
@@ -32,7 +41,7 @@ export class RenderModule {
           provide: RenderService,
           useFactory: (nestHost: HttpAdapterHost): RenderService => {
             return RenderService.init(
-              options,
+              config,
               next.getRequestHandler(),
               next.render.bind(next),
               next.renderError.bind(next),

--- a/lib/render.service.ts
+++ b/lib/render.service.ts
@@ -48,6 +48,9 @@ export class RenderService {
     if (typeof config.viewsDir === 'string' || config.viewsDir === null) {
       this.config.viewsDir = config.viewsDir;
     }
+    if (typeof config.basePath === 'string') {
+      this.config.basePath = config.basePath;
+    }
   }
 
   /**
@@ -145,6 +148,10 @@ export class RenderService {
    * @param url
    */
   public isInternalUrl(url: string): boolean {
+    if (this.config.basePath && url.startsWith(this.config.basePath)) {
+      return isInternalUrl(url.replace(this.config.basePath, ''));
+    }
+
     return isInternalUrl(url);
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -33,6 +33,7 @@ export type ErrorHandler = (
 
 export interface RendererConfig {
   viewsDir: null | string;
+  basePath?: string;
   dev: boolean;
 }
 


### PR DESCRIPTION
Changes are made to support both injecting a custom base path through options and pulling base path from local Next config from injected Next Server instance. Explicit base path in RenderModule options is used over the one from Next config if specified.

This PR closes #78.