### PR TITLE
Support specyfing index page as /

### DIFF
--- a/lib/render.service.ts
+++ b/lib/render.service.ts
@@ -1,3 +1,4 @@
+import path from 'path/posix';
 import { HttpServer, InternalServerErrorException } from '@nestjs/common';
 import { ParsedUrlQuery } from 'querystring';
 import { isInternalUrl } from './next-utils';
@@ -254,6 +255,6 @@ export class RenderService {
   protected getViewPath(view: string) {
     const baseDir = this.getViewsDir();
     const basePath = baseDir ? baseDir : '';
-    return `${basePath}/${view}`;
+    return path.normalize(`${basePath}/${view}`);
   }
 }


### PR DESCRIPTION
Thank you for this library. It's really lifesaving. But there's a thing which might be improved. I expected that I can use the same path for `@Get` and `@Render` decorators. But when I tried to render an index page this way `@Render('/')` I've got an error `Error: Requested and resolved page mismatch: // /`.
If I had a way to use the same paths, I would combine them in one `@Page` decorator. It would allow me to not repeat myself every time I want to render a page. The only thing required for that is to normalize given path to collapse double slashes.